### PR TITLE
Fix: Correct arrowhead x-axis positioning in timelines

### DIFF
--- a/tiny-timeline.html
+++ b/tiny-timeline.html
@@ -46,10 +46,10 @@
     <svg version="1.1" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
          xmlns="http://www.w3.org/2000/svg" :viewBox="'46.0 -0.3 734.8 ' + (rows.length * 200 + 60)" :width="734.8" :height="rows.length * 200 + 80">
         <defs>
-            <marker id="arrowhead" markerWidth="5" markerHeight="3.5" refX="2.5" refY="1.75" orient="auto">
+            <marker id="arrowhead" markerWidth="5" markerHeight="3.5" refX="0" refY="1.75" orient="auto">
                 <polygon points="0 0, 5 1.75, 0 3.5" fill="#90ee90"/>
             </marker>
-            <marker id="arrowhead-ltr" markerWidth="5" markerHeight="3.5" refX="-4.5" refY="1.75" orient="auto">
+            <marker id="arrowhead-ltr" markerWidth="5" markerHeight="3.5" refX="5" refY="1.75" orient="auto">
                 <polygon points="0 0, 5 1.75, 0 3.5" fill="#90ee90"/>
             </marker>
         </defs>


### PR DESCRIPTION
I adjusted the refX attribute for both left-pointing and right-pointing arrowheads (arrowhead and arrowhead-ltr markers respectively) in the SVG definition within tiny-timeline.html.

- For the left-pointing arrowhead (id='arrowhead'), I changed refX from '2.5' to '0'.
- For the right-pointing arrowhead (id='arrowhead-ltr'), I changed refX from '-4.5' to '5'.

These changes ensure that the tip of the arrowhead polygon aligns correctly with the end of the path it is marking, resolving an issue where the final arrowhead on timelines was offset on the x-axis.