### PR TITLE
Fix: Fine-tune arrowhead x-axis positioning

### DIFF
--- a/tiny-timeline.html
+++ b/tiny-timeline.html
@@ -46,7 +46,7 @@
     <svg version="1.1" xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/"
          xmlns="http://www.w3.org/2000/svg" :viewBox="'46.0 -0.3 734.8 ' + (rows.length * 200 + 60)" :width="734.8" :height="rows.length * 200 + 80">
         <defs>
-            <marker id="arrowhead" markerWidth="5" markerHeight="3.5" refX="0" refY="1.75" orient="auto">
+            <marker id="arrowhead" markerWidth="5" markerHeight="3.5" refX="-7.5" refY="1.75" orient="auto">
                 <polygon points="0 0, 5 1.75, 0 3.5" fill="#90ee90"/>
             </marker>
             <marker id="arrowhead-ltr" markerWidth="5" markerHeight="3.5" refX="5" refY="1.75" orient="auto">


### PR DESCRIPTION
This commit further adjusts the refX attribute for the SVG arrowhead markers based on detailed visual feedback.

- The `id="arrowhead"` marker (primarily affecting the Spaceflight timeline) has its `refX` value changed to `-7.5`. This is to correct an issue where it appeared too far to the right.
- The `id="arrowhead-ltr"` marker (primarily affecting the Women's Rights timeline) remains at `refX="5"`, which was previously confirmed as correct.

These changes aim to ensure precise arrowhead alignment on the x-axis for all timelines.