### PR TITLE
Docs: Add Test Timelines section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ Women's rights: https://paul-hammant.github.io/tiny-timeline//tiny-timeline.html
 Spaceflight Milestones: https://paul-hammant.github.io/tiny-timeline//tiny-timeline.html#spaceflight-milestones
 
 Lots to do.  
+
+## Test Timelines
+
+The `tests/` directory contains JSON files for testing the timeline rendering with varying numbers of entries. These files use 'lorem ipsum' placeholder text.
+
+- `tests/one-timeline-entry.json`: Contains 1 timeline entry.
+- `tests/two-timeline-entries.json`: Contains 2 timeline entries.
+- `tests/three-timeline-entries.json`: Contains 3 timeline entries.
+- `tests/four-timeline-entries.json`: Contains 4 timeline entries.
+- `tests/five-timeline-entries.json`: Contains 5 timeline entries.
+- `tests/six-timeline-entries.json`: Contains 6 timeline entries.
+- `tests/seven-timeline-entries.json`: Contains 7 timeline entries.
+- `tests/eight-timeline-entries.json`: Contains 8 timeline entries.


### PR DESCRIPTION
I've added a new section to README.md to list and describe the test timeline JSON files available in the tests/ directory.

This includes entries for timelines with 1 through 8 items.